### PR TITLE
Fix compiling errors for OCaml 4.09.0

### DIFF
--- a/bin/bin/dep.ml
+++ b/bin/bin/dep.ml
@@ -177,7 +177,7 @@ let copy_images root src =
   let dir = Filename.dirname dst in
   let cmd = sprintf "mkdir -p %s && cp %s %s" dir src dst in
   sprintf "exec: %s" cmd |> print_endline;
-  Sys.command cmd |> ignore
+  ( Sys.command cmd : int) |> ignore
 
 let copy_files_to_static root exts copy =
   let build_dir = sprintf "%s/_build/default/book" root in
@@ -195,9 +195,9 @@ let process_examples example_dir =
     print_endline dir
   )
 
-let _ =
+let _ : unit = 
   let root = Sys.argv.(1) in
-  copy_files_to_static root image_extensions copy_images;
+  let _x : unit = copy_files_to_static root  image_extensions  copy_images in
   let toc = read_toc "book" in
-  process_md ~toc "book";
+  let _x : unit = process_md ~toc "book" in 
   process_chapters ~toc "book" "static"

--- a/bin/bin/dep.ml
+++ b/bin/bin/dep.ml
@@ -195,7 +195,7 @@ let process_examples example_dir =
     print_endline dir
   )
 
-let () = 
+let () =
   let root = Sys.argv.(1) in
   copy_files_to_static root image_extensions copy_images;
   let toc = read_toc "book" in

--- a/bin/bin/dep.ml
+++ b/bin/bin/dep.ml
@@ -195,9 +195,9 @@ let process_examples example_dir =
     print_endline dir
   )
 
-let _ : unit = 
+let () = 
   let root = Sys.argv.(1) in
-  let _x : unit = copy_files_to_static root  image_extensions  copy_images in
+  let _x : unit = copy_files_to_static root image_extensions copy_images in
   let toc = read_toc "book" in
   let _x : unit = process_md ~toc "book" in 
   process_chapters ~toc "book" "static"

--- a/bin/bin/dep.ml
+++ b/bin/bin/dep.ml
@@ -197,7 +197,7 @@ let process_examples example_dir =
 
 let () = 
   let root = Sys.argv.(1) in
-  let _x : unit = copy_files_to_static root image_extensions copy_images in
+  copy_files_to_static root image_extensions copy_images;
   let toc = read_toc "book" in
-  let _x : unit = process_md ~toc "book" in 
+  process_md ~toc "book";
   process_chapters ~toc "book" "static"

--- a/bin/lib/html.ml
+++ b/bin/lib/html.ml
@@ -56,7 +56,7 @@ let to_string t =
 
 let is_elem_node item name' = match item with
   | `Data _ -> false
-  | `Element {name; _} -> Stdlib.(=) name' name
+  | `Element {name; _} -> String.(name' = name)
 
 let has_html_extension file =
   Filename.split_extension file
@@ -74,7 +74,7 @@ let get_all_nodes tag t =
     List.fold t ~init:[] ~f:(fun accum item ->
       match item with
       | `Element {name; childs; _} ->
-        if Stdlib.(=) name tag then
+        if String.(name = tag) then
           item::accum
         else
           (helper childs)@accum
@@ -88,10 +88,10 @@ let is_nested name t =
   let rec loop have_seen = function
     | `Data _ -> false
     | `Element {name=name'; childs; _} ->
-      if have_seen && (Stdlib.(=) name name') then
+      if have_seen && String.(name = name') then
         true
       else
-        let have_seen = have_seen || (Stdlib.(=) name name') in
+        let have_seen = have_seen || String.(name = name') in
         List.exists childs ~f:(loop have_seen)
   in
   List.exists t ~f:(loop false)

--- a/bin/lib/html.ml
+++ b/bin/lib/html.ml
@@ -56,7 +56,7 @@ let to_string t =
 
 let is_elem_node item name' = match item with
   | `Data _ -> false
-  | `Element {name; _} -> name' = name
+  | `Element {name; _} -> Stdlib.(=) name' name
 
 let has_html_extension file =
   Filename.split_extension file
@@ -74,7 +74,7 @@ let get_all_nodes tag t =
     List.fold t ~init:[] ~f:(fun accum item ->
       match item with
       | `Element {name; childs; _} ->
-        if name = tag then
+        if Stdlib.(=) name tag then
           item::accum
         else
           (helper childs)@accum
@@ -88,10 +88,10 @@ let is_nested name t =
   let rec loop have_seen = function
     | `Data _ -> false
     | `Element {name=name'; childs; _} ->
-      if have_seen && (name = name') then
+      if have_seen && (Stdlib.(=) name name') then
         true
       else
-        let have_seen = have_seen || (name = name') in
+        let have_seen = have_seen || (Stdlib.(=) name name') in
         List.exists childs ~f:(loop have_seen)
   in
   List.exists t ~f:(loop false)

--- a/bin/lib/index.ml
+++ b/bin/lib/index.ml
@@ -6,7 +6,7 @@ let nbsp = `Data (List.hd_exn (Soup.(texts (parse "&nbsp;"))))
 let indexterm_to_idx docs =
   let rec loop item = match item with
     | `Data _ -> item
-    | `Element {name="a"; attrs; childs=[x]} when x = nbsp -> (
+    | `Element {name="a"; attrs; childs=[x]} when Stdlib.(=) x nbsp -> (
       if List.mem ~equal:Util.string_pair_equal attrs ("data-type", "indexterm")
       then (
         match
@@ -42,8 +42,8 @@ let idx_to_indexterm t =
   let rec loop item = match item with
     | `Data _ -> item
     | `Element {name="span"; attrs; childs=[`Data data]}
-      when List.Assoc.find ~equal:(=) attrs "class" = Some "idx"->
-      let attrs = List.filter attrs ~f:(fun (x, _) -> x <> "class") in
+      when Stdlib.(=) (List.Assoc.find ~equal:(Stdlib.(=)) attrs "class") (Some "idx")->
+      let attrs = List.filter attrs ~f:(fun (x, _) -> Stdlib.(<>) x "class") in
       (match String.split data ~on:'/' with
       | x::[] ->
         `Element {

--- a/bin/lib/index.ml
+++ b/bin/lib/index.ml
@@ -6,7 +6,7 @@ let nbsp = `Data (List.hd_exn (Soup.(texts (parse "&nbsp;"))))
 let indexterm_to_idx docs =
   let rec loop item = match item with
     | `Data _ -> item
-    | `Element {name="a"; attrs; childs=[x]} when Stdlib.(=) x nbsp -> (
+    | `Element {name="a"; attrs; childs=[x]} when Base.Poly.(x = nbsp) -> (
       if List.mem ~equal:Util.string_pair_equal attrs ("data-type", "indexterm")
       then (
         match
@@ -42,8 +42,8 @@ let idx_to_indexterm t =
   let rec loop item = match item with
     | `Data _ -> item
     | `Element {name="span"; attrs; childs=[`Data data]}
-      when Stdlib.(=) (List.Assoc.find ~equal:(Stdlib.(=)) attrs "class") (Some "idx")->
-      let attrs = List.filter attrs ~f:(fun (x, _) -> Stdlib.(<>) x "class") in
+      when Base.Poly.(List.Assoc.find ~equal:String.equal attrs "class" = Some "idx") ->
+      let attrs = List.filter attrs ~f:(fun (x, _) -> String.(x <> "class")) in
       (match String.split data ~on:'/' with
       | x::[] ->
         `Element {

--- a/bin/lib/toc.ml
+++ b/bin/lib/toc.ml
@@ -58,7 +58,7 @@ let html_to_title html =
 
 (* Convert section title to a valid HTML ID. *)
 let title_to_id s =
-  String.filter s ~f:(fun c -> Char.is_alphanum c || c = ' ')
+  String.filter s ~f:(fun c -> Char.is_alphanum c || Char.equal c ' ')
   |> String.map ~f:(function ' ' -> '-' | c -> c)
 
 let split_into_sections ~filename items =
@@ -175,7 +175,7 @@ let of_chapters (chapters : chapter list) : part list =
     | p::rest ->
       let prev_part = p.info in
       let curr_part = x.part_info in
-      if prev_part = curr_part then
+      if Stdlib.(=) prev_part curr_part then
         {p with chapters = x::p.chapters}::rest
       else
           {info = curr_part; chapters = [x]}::p::rest
@@ -209,7 +209,7 @@ let find ~name (t:t) =
   let rec aux = function
     | []   -> None
     | h::t ->
-      match List.find h.chapters ~f:(fun c -> c.name = name) with
+      match List.find h.chapters ~f:(fun c -> String.equal c.name name) with
       | Some _ as x -> x
       | None -> aux t
   in

--- a/bin/lib/toc.ml
+++ b/bin/lib/toc.ml
@@ -58,7 +58,7 @@ let html_to_title html =
 
 (* Convert section title to a valid HTML ID. *)
 let title_to_id s =
-  String.filter s ~f:(fun c -> Char.is_alphanum c || Char.equal c ' ')
+  String.filter s ~f:(fun c -> Char.is_alphanum c || Char.(c = ' '))
   |> String.map ~f:(function ' ' -> '-' | c -> c)
 
 let split_into_sections ~filename items =
@@ -175,7 +175,7 @@ let of_chapters (chapters : chapter list) : part list =
     | p::rest ->
       let prev_part = p.info in
       let curr_part = x.part_info in
-      if Stdlib.(=) prev_part curr_part then
+      if Poly.(prev_part = curr_part) then
         {p with chapters = x::p.chapters}::rest
       else
           {info = curr_part; chapters = [x]}::p::rest
@@ -209,7 +209,7 @@ let find ~name (t:t) =
   let rec aux = function
     | []   -> None
     | h::t ->
-      match List.find h.chapters ~f:(fun c -> String.equal c.name name) with
+      match List.find h.chapters ~f:(fun c -> String.(c.name = name)) with
       | Some _ as x -> x
       | None -> aux t
   in


### PR DESCRIPTION
This PR fixes the compiling errors when update OCaml to version 4.09.0 (or higher), following the fix done in [this commit](https://github.com/realworldocaml/book/commit/ad3b1f749086b27546c88b300743b0043b462135).